### PR TITLE
Added a option to set the 'current' class name. 

### DIFF
--- a/source/slides.jquery.js
+++ b/source/slides.jquery.js
@@ -1,4 +1,7 @@
 /*
+*
+*===========!!!!!!!!!---- MODIFIED: my fork is at https://github.com/arronmabrey/Slides ----!!!!!!!!!===========
+*
 * Slides, A Slideshow Plugin for jQuery
 * Intructions: http://slidesjs.com
 * By: Nathan Searles, http://nathansearles.com


### PR DESCRIPTION
Hi nathan,

I added a option to set the 'current' class name.

It still defaults to 'current'

I had a situation where I needed to use the class name 'active'. 

Thats it nice and simple.

Thanks alot and keep up the good work.

Arron
