### PR TITLE
Adding the ability to have the pagination come before the slides.

### DIFF
--- a/source/slides.js
+++ b/source/slides.js
@@ -536,7 +536,7 @@
 			responsive: false, // [Boolean] slideshow will scale to its container
 			height: 300, // [Number] Define the slide height
 			navigation: true, // [Boolean] Auto generate the naviagation, next/previous buttons
-			pagination: "append", // [String] Can be either "apend" or "prepend". You can also pass [Boolean] false to disable Auto generation.
+			pagination: "append", // [String] Can be either "append" or "prepend". You can also pass [Boolean] false to disable Auto generation.
 			effects: {
 				navigation: "slide",  // [String] Can be either "slide" or "fade"
 				pagination: "slide" // [String] Can be either "slide" or "fade"


### PR DESCRIPTION
Hi Nathan,

I have a case where the design I'm working on calls for the pagination dots to sit above the slides. That part is easy, all I need is a bit of relative positioning to pull them up top.

The problem I ran into was we have multiple slideshows on a page with varying height. So as you can imagine relative positioning doesn't work very well in that situation. I would have to class each slideshow and style them individually based on that particular slide height and that doesn't scale very well.

I need the pagination to come before the slides in the DOM. I changed the pagination option to accept 'append', 'prepend' and false.

Everything defaults to what you had set, 'append' and 'prepend' both pass as true in your checks.

I did think about using a more semantic approach:

```
pagination: {
  active:      true     // [Boolean] Auto generate the pagination.
  position:  "after"  // [String] Can be either "before" or "after".
}
```

But I wanted to keep my changes as minimal as possible until I got some feedback from you.

Thanks

Arron Mabrey
