### PR TITLE
Adding: the ability for pagination to have meaningful text in links.

### DIFF
--- a/source/slides.js
+++ b/source/slides.js
@@ -726,7 +726,7 @@
 			
 			this.slides.each(
 				$.proxy(function(index, element) {
-					$("<li><a href='#" + index + "' class='slidesNavigation slidesPaginationItem' data-slidesindex=" + index + "> " + ( index + 1 ) + "</a></li>").appendTo(this.pagination);
+					$("<li><a href='#" + index + "' class='slidesNavigation slidesPaginationItem' data-slidesindex=" + index + "> " + ( $(element).data("slideslabel") || index + 1 ) + "</a></li>").appendTo(this.pagination);
 				},this)
 			);
 			


### PR DESCRIPTION
Adding: the ability for pagination to have meaningful text in links instead just the slide number.

Sharing back changes from a project I did.

```
<div class="slides">
  <img data-slideslabel="Image One" src="image01.jpg" />
  <img data-slideslabel="Image Two" src="image02.jpg" />
  <img data-slideslabel="Image Three" src="image03.jpg" />
</div>
```

Also if there is no data-slideslabel set it will default back to the number for the slide.
