### PR TITLE
"slide to" breaks Prev/Next buttons navigation

### DIFF
--- a/source/slides.js
+++ b/source/slides.js
@@ -760,6 +760,7 @@
 		slide: function( slide, effect ) {			
 			this.element.data("goto", (slide - 1));
 			this._navigate("pagination", effect);
+			this.element.data("goto", null);
 		},
 		_navigate: function( event, effect ) {
 			var to, position, direction, next, prev, pagination, $target = $(event.target), currentSlide = this.slides.eq( this.current );


### PR DESCRIPTION
Quick hotfix for scenario:

$('#slides').slides('slide', 1);

Going to the specific slide via this command breaks Prev/Next buttons navigation.
