### PR TITLE
Update jquery.slides.js - use jquery delegate for navigation click event...

### DIFF
--- a/source/jquery.slides.js
+++ b/source/jquery.slides.js
@@ -127,12 +127,12 @@
           text: "Next"
         }).appendTo($element);
       }
-      $(".slidesjs-next", $element).click(function(e) {
+      $($element).delegate(".slidesjs-next", "click", function(e) {
         e.preventDefault();
         _this.stop(true);
         return _this.next(_this.options.navigation.effect);
       });
-      $(".slidesjs-previous", $element).click(function(e) {
+      $($element).delegate(".slidesjs-previous", "click", function(e) {
         e.preventDefault();
         _this.stop(true);
         return _this.previous(_this.options.navigation.effect);
@@ -200,7 +200,7 @@
       this.data = $.data(this);
       current = number > -1 ? number : this.data.current;
       $(".active", $element).removeClass("active");
-      return $(".slidesjs-pagination li:eq(" + current + ") a", $element).addClass("active");
+      return $(".slidesjs-pagination li.slidesjs-pagination-item:eq(" + current + ") a", $element).addClass("active");
     };
     Plugin.prototype.update = function() {
       var $element, height, width;


### PR DESCRIPTION
Update jquery.slides.js - use jquery delegate for navigation click events instead of jquery click; specify slidesjs-pagination-item for 'active' class selector

This allows the user to add in additional navigation buttons after the slidersjs is initialized. My personal use case was adding navigation buttons to the pagination list:
var pagination = $('.slidesjs-pagination', container);
$('.slidesjs-pagination-item:first', pagination).before(
    '<li>' +
    '<a href="#" class="pagination-nav slidesjs-previous slidesjs-navigation"></a>' +
    '</li>'
);
pagination.append(
    '<li>' +
    '<a href="#" class="pagination-nav slidesjs-next slidesjs-navigation"></a>' +
    '</li>'
);
