### PR TITLE
Giving an integer value to the height

### DIFF
--- a/source/jquery.slides.coffee
+++ b/source/jquery.slides.coffee
@@ -300,7 +300,7 @@
 
     # Get the new width and height
     width = $element.width()
-    height = (@options.height / @options.width) * width
+    height = Math.floor((@options.height / @options.width) * width)
 
     # Store new width and height
     @options.width = width


### PR DESCRIPTION
When having various sliders one after each another, a 1px margin can appear if we don't take care of flooring the height value
