### PR TITLE
Issue #584 by 90arther: Please don't use ECMA-262 reserved word

### DIFF
--- a/source/jquery.slides.js
+++ b/source/jquery.slides.js
@@ -181,7 +181,7 @@
           return paginationLink.click(function(e) {
             e.preventDefault();
             _this.stop(true);
-            return _this.goto(($(e.currentTarget).attr("data-slidesjs-item") * 1) + 1);
+            return _this.goTo(($(e.currentTarget).attr("data-slidesjs-item") * 1) + 1);
           });
         });
       }
@@ -248,7 +248,7 @@
         return this._slide();
       }
     };
-    Plugin.prototype.goto = function(number) {
+    Plugin.prototype.goTo = function(number) {
       var $element, effect;
       $element = $(this.element);
       this.data = $.data(this);


### PR DESCRIPTION
The Plugin use 'goto' as a function which had be a reserver word in ECMA-262.
When I use YUI compiler to compiler the file, it will be a error.
Please use Camel-case. 
Please replace it with 'goTo'.
